### PR TITLE
✦ [ABDK #1] Fix solidity version

### DIFF
--- a/src/RiseToken.sol
+++ b/src/RiseToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";

--- a/src/RiseTokenFactory.sol
+++ b/src/RiseTokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { Ownable } from "openzeppelin/access/Ownable.sol";

--- a/src/adapters/RariFusePriceOracleAdapter.sol
+++ b/src/adapters/RariFusePriceOracleAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { Ownable } from "openzeppelin/access/Ownable.sol";

--- a/src/adapters/UniswapAdapter.sol
+++ b/src/adapters/UniswapAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { Ownable } from "openzeppelin/access/Ownable.sol";

--- a/src/interfaces/IFuseComptroller.sol
+++ b/src/interfaces/IFuseComptroller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IRariFusePriceOracle.sol
+++ b/src/interfaces/IRariFusePriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IRariFusePriceOracleAdapter.sol
+++ b/src/interfaces/IRariFusePriceOracleAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { IRariFusePriceOracle } from "./IRariFusePriceOracle.sol";

--- a/src/interfaces/IRiseToken.sol
+++ b/src/interfaces/IRiseToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/IRiseTokenFactory.sol
+++ b/src/interfaces/IRiseTokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { UniswapAdapter } from "../adapters/UniswapAdapter.sol";

--- a/src/interfaces/IUniswapAdapter.sol
+++ b/src/interfaces/IUniswapAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/IUniswapAdapterCaller.sol
+++ b/src/interfaces/IUniswapAdapterCaller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IUniswapV2Factory.sol
+++ b/src/interfaces/IUniswapV2Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IUniswapV2Pair.sol
+++ b/src/interfaces/IUniswapV2Pair.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IUniswapV2Router02.sol
+++ b/src/interfaces/IUniswapV2Router02.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IUniswapV3Pool.sol
+++ b/src/interfaces/IUniswapV3Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IUniswapV3SwapRouter.sol
+++ b/src/interfaces/IUniswapV3SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/interfaces/IWETH9.sol
+++ b/src/interfaces/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";

--- a/src/interfaces/IfERC20.sol
+++ b/src/interfaces/IfERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/src/test/RiseTokenFactoryTest.sol
+++ b/src/test/RiseTokenFactoryTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/RiseTokenTest.sol
+++ b/src/test/RiseTokenTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/adapters/RariFusePriceOracleAdapter.t.sol
+++ b/src/test/adapters/RariFusePriceOracleAdapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/adapters/UniswapAdapterTest.sol
+++ b/src/test/adapters/UniswapAdapterTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";

--- a/src/test/arbitrum/Tokens.sol
+++ b/src/test/arbitrum/Tokens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 // ERC20 addresses on Arbitrum

--- a/src/test/ethereum/Tokens.sol
+++ b/src/test/ethereum/Tokens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 // ERC20 addresses on Ethereum

--- a/src/test/hevm/HEVM.sol
+++ b/src/test/hevm/HEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import { usdc, usdcSlot } from "chain/Tokens.sol";

--- a/src/test/hevm/HEVM.t.sol
+++ b/src/test/hevm/HEVM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.11;
+pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import "ds-test/test.sol";


### PR DESCRIPTION
# Report

Specifying a particular compiler version makes it harder to migrate to newer versions.  

# Recommendation
Consider specifying as "^0.8.0".
