### PR TITLE
ABDK 22 - Remove .decimals() usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/solmate"]
+	path = lib/solmate
+	url = https://github.com/Rari-Capital/solmate

--- a/src/adapters/RariFusePriceOracleAdapter.sol
+++ b/src/adapters/RariFusePriceOracleAdapter.sol
@@ -69,7 +69,7 @@ contract RariFusePriceOracleAdapter is IRariFusePriceOracleAdapter, Ownable {
     }
 
     /// @inheritdoc IRariFusePriceOracleAdapter
-    function value(
+    function totalValue(
         address _base,
         address _quote,
         uint256 _baseAmount

--- a/src/interfaces/IRariFusePriceOracleAdapter.sol
+++ b/src/interfaces/IRariFusePriceOracleAdapter.sol
@@ -96,7 +96,7 @@ interface IRariFusePriceOracleAdapter {
      * @param _baseAmount The amount of base token (e.g. 100 gOHM)
      * @return _value The total value in quote decimals precision (e.g. USDC is 1e6)
      */
-    function value(
+    function totalValue(
         address _base,
         address _quote,
         uint256 _baseAmount

--- a/src/interfaces/IRariFusePriceOracleAdapter.sol
+++ b/src/interfaces/IRariFusePriceOracleAdapter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-
 import { IRariFusePriceOracle } from "./IRariFusePriceOracle.sol";
 
 /**
@@ -10,20 +9,20 @@ import { IRariFusePriceOracle } from "./IRariFusePriceOracle.sol";
  * @notice Adapter for Rari Fuse Price Oracle
  */
 interface IRariFusePriceOracleAdapter {
-    /// ███ Types ██████████████████████████████████████████████████████████████
+    /// ███ Types ████████████████████████████████████████████████████████████
 
     /**
      * @notice Oracle metadata
      * @param oracle The Rari Fuse oracle
-     * @param decimals The token decimals
+     * @param precision The token precision (e.g. USDC is 1e6)
      */
     struct OracleMetadata {
         IRariFusePriceOracle oracle;
-        uint8 decimals;
+        uint256 precision;
     }
 
 
-    /// ███ Events █████████████████████████████████████████████████████████████
+    /// ███ Events ███████████████████████████████████████████████████████████
 
     /**
      * @notice Event emitted when oracle data is updated
@@ -36,26 +35,28 @@ interface IRariFusePriceOracleAdapter {
     );
 
 
-    /// ███ Errors █████████████████████████████████████████████████████████████
+    /// ███ Errors ███████████████████████████████████████████████████████████
 
     /// @notice Error is raised when base or quote token oracle is not exists
     error OracleNotExists(address token);
 
 
-    /// ███ Owner actions ██████████████████████████████████████████████████████
+    /// ███ Owner actions ████████████████████████████████████████████████████
 
     /**
      * @notice Configure oracle for token
      * @param _token The ERC20 token
-     * @param _rariFusePriceOracle Contract that conform IRariFusePriceOracle interface
+     * @param _rariFusePriceOracle Contract that conform IRariFusePriceOracle
+     * @param _decimals The ERC20 token decimals
      */
     function configure(
         address _token,
-        address _rariFusePriceOracle
+        address _rariFusePriceOracle,
+        uint8 _decimals
     ) external;
 
 
-    /// ███ Read-only functions ████████████████████████████████████████████████
+    /// ███ Read-only functions ██████████████████████████████████████████████
 
     /**
      * @notice Returns true if oracle for the `_token` is configured
@@ -64,7 +65,7 @@ interface IRariFusePriceOracleAdapter {
     function isConfigured(address _token) external view returns (bool);
 
 
-    /// ███ Adapters ███████████████████████████████████████████████████████████
+    /// ███ Adapters █████████████████████████████████████████████████████████
 
     /**
      * @notice Gets the price of `_token` in terms of ETH (1e18 precision)
@@ -85,5 +86,20 @@ interface IRariFusePriceOracleAdapter {
         address _base,
         address _quote
     ) external view returns (uint256 _price);
+
+    /**
+     * @notice Gets the total value of `_baseAmount` in terms of `_quote`.
+     *         For example 100 gOHM/USDC will return current price of 10 gOHM
+     *         in USDC (1e6 precision).
+     * @param _base Base token address (e.g. gOHM/XXX)
+     * @param _quote Quote token address (e.g. XXX/USDC)
+     * @param _baseAmount The amount of base token (e.g. 100 gOHM)
+     * @return _value The total value in quote decimals precision (e.g. USDC is 1e6)
+     */
+    function value(
+        address _base,
+        address _quote,
+        uint256 _baseAmount
+    ) external view returns (uint256 _value);
 
 }

--- a/src/interfaces/IRiseToken.sol
+++ b/src/interfaces/IRiseToken.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-
 import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";
 
@@ -46,24 +45,21 @@ interface IRiseToken is IERC20 {
      * @notice Parameters that used to buy the Rise Token
      * @param buyer The msg.sender
      * @param recipient The address that will receive the Rise Token
-     * @param tokenIn The ERC20 that used to buy the Rise Token
      * @param collateralAmount The amount of token that will supplied to Rari Fuse
      * @param debtAmount The amount of token that will borrowed from Rari Fuse
      * @param shares The amount of Rise Token to be minted
      * @param fee The amount of Rise Token as fee
-     * @param amountInMax The maximum amount of tokenIn, useful for setting the
-     *                    slippage tolerance.
+     * @param wethAmount The WETH amount from tokenIn
      * @param nav The net-asset value of the Rise Token
      */
     struct BuyParams {
         address buyer;
         address recipient;
-        ERC20 tokenIn;
         uint256 collateralAmount;
         uint256 debtAmount;
         uint256 shares;
         uint256 fee;
-        uint256 amountInMax;
+        uint256 wethAmount;
         uint256 nav;
     }
 
@@ -71,24 +67,19 @@ interface IRiseToken is IERC20 {
      * @notice Parameters that used to buy the Rise Token
      * @param seller The msg.sender
      * @param recipient The address that will receive the tokenOut
-     * @param tokenOut The ERC20 that will received by recipient
      * @param collateralAmount The amount of token that will redeemed from Rari Fuse
      * @param debtAmount The amount of token that will repay to Rari Fuse
      * @param shares The amount of Rise Token to be burned
      * @param fee The amount of Rise Token as fee
-     * @param amountOutMin The minimum amount of tokenOut, useful for setting the
-     *                    slippage tolerance.
      * @param nav The net-asset value of the Rise Token
      */
     struct SellParams {
         address seller;
         address recipient;
-        ERC20 tokenOut;
         uint256 collateralAmount;
         uint256 debtAmount;
         uint256 shares;
         uint256 fee;
-        uint256 amountOutMin;
         uint256 nav;
     }
 
@@ -130,7 +121,7 @@ interface IRiseToken is IERC20 {
     error NotUniswapAdapter();
 
     /// @notice Error is raised if mint amount is invalid
-    error InputAmountInvalid();
+    error InitializeAmountInInvalid();
 
     /// @notice Error is raised if the owner run the initialize() twice
     error AlreadyInitialized();
@@ -222,13 +213,14 @@ interface IRiseToken is IERC20 {
      * @param _shares The amount of Rise Token to buy
      * @param _recipient The recipient of the transaction.
      * @param _tokenIn ERC20 used to buy the Rise Token
+     * @return _amountIn The amount of tokenIn used to mint Rise Token
      */
     function buy(
         uint256 _shares,
         address _recipient,
         address _tokenIn,
         uint256 _amountInMax
-    ) external payable;
+    ) external payable returns (uint256 _amountIn);
 
     /**
      * @notice Sell Rise Token for tokenOut. The _shares amount of Rise Token will be burned.
@@ -242,7 +234,7 @@ interface IRiseToken is IERC20 {
         address _recipient,
         address _tokenOut,
         uint256 _amountOutMin
-    ) external;
+    ) external returns (uint256 _amountOut);
 
 
     /// ███ Market makers ██████████████████████████████████████████████████████

--- a/src/interfaces/IRiseToken.sol
+++ b/src/interfaces/IRiseToken.sol
@@ -310,6 +310,48 @@ interface IRiseToken is IERC20 {
      *
      * In this case, market price is determined using Rari Fuse Oracle Adapter.
      *
+     * ------------
+     * Maximum Swap Amount
+     *
+     * The maximum swap amount is determined by the rebalancing step.
+     *
+     * Lr : Leverage ratio after rebalancing
+     * L  : Current leverage ratio
+     * ΔL : The rebelancing step
+     *      ΔL > 0 leveraging up
+     *      ΔL < 0 leveraging down
+     * V  : Net asset value
+     * C  : Current collateral value
+     * Cr : Collateral value after rebalancing
+     * D  : Current debt value
+     * Dr : Debt value after rebalancing
+     *
+     * The rebalancing process is defined as below:
+     *
+     *     Lr = L + ΔL ................................................... (1)
+     *
+     * The leverage ratio is defined as below:
+     *
+     *     L  = C / V .................................................... (2)
+     *     Lr = Cr / Vr .................................................. (3)
+     *
+     * The net asset value is defined as below:
+     *
+     *     V  = C - D .................................................... (4)
+     *     Vr = Cr - Dr .................................................. (5)
+     *
+     * The net asset value before and after rebalancing should be equal.
+     *
+     *     V = Vr ........................................................ (6)
+     *
+     * Using equation above we got the debt value after rebalancing given ΔL:
+     *
+     *     Dr = C - D + Cr ............................................... (7)
+     *     Dr = D + (ΔL * V) ............................................. (8)
+     *
+     * So the maximum swap amount is ΔLV.
+     *     ΔL > 0 Supply collateral then borrow (swapCollateralForETH)
+     *     ΔL < 0 Repay debt and redeem collateral (swapETHForCollateral)
      */
 
      /**


### PR DESCRIPTION
# Report

In ERC20 the optional property "decimals" is used by UI to render token amounts in a human-friendly way.  Using this property in smart contracts is discouraged.  

# Recommendation

Consider treating all token amounts as integers.